### PR TITLE
exporting the directory of git-hooks binary

### DIFF
--- a/git-hooks
+++ b/git-hooks
@@ -170,7 +170,7 @@ function install_hooks
             return 1
         fi
     cmd='#!/usr/bin/env bash
-git-hooks run "$0" "$@"';
+~/bin/git-hooks run "$0" "$@"';
     install_hooks_into "${PWD}" "${cmd}"
     else
         if [ ! -d hooks.old ] ; then
@@ -196,7 +196,7 @@ function install_global
             mkdir -p "${TEMPLATE}/hooks"
         fi
     cmd='#!/usr/bin/env bash
-git-hooks run "$0" "$@"';
+~/bin/git-hooks run "$0" "$@"';
         install_hooks_into "${TEMPLATE}" "${cmd}"
         mv "${TEMPLATE}/hooks.old" "${TEMPLATE}/hooks.original"
     fi
@@ -237,7 +237,7 @@ case $1 in
     -h|--help|-? )
         echo 'Git Hooks'
         echo '    A tool to manage project, user, and global Git hooks for multiple git repositories.'
-        echo '    https://github.com/icefox/git-hooks'
+        echo '    https://github.com/autonomic-ai/git-hooks'
         echo ''
         echo 'Options:'
         echo '    --install      Replace existing hooks in this repository with a call to'


### PR DESCRIPTION
Otherwise, this will fail brew tap as a post-checkout hook will attempt
to run without `git-hooks` available through the `$PATH`. The alternative is to rollback the global installation script
and force users to explictly run git hooks install per repo.

This very heavily depends on the user installing `git-hooks` through `engineering/bin/setup_git_hooks` as it expects the executable to be placed under `~/bin`.